### PR TITLE
Fix: Adjust internal links for GitHub Pages compatibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -247,7 +247,7 @@
                     <div class="p-6 text-center">
                         <h3 class="text-xl font-bold mb-3">The Climate Sanctuary</h3>
                         <p class="mb-4 text-gray-600">A self-contained cocoon of comfort, featuring advanced Icebound Mode. Inspired by officer's bed frames of the expedition.</p>
-                        <a href="/products/sanctuary.html" class="pre-order-button w-full">View Editions</a>
+                        <a href="products_sanctuary.html" class="pre-order-button w-full">View Editions</a>
                     </div>
                 </div>
                 <div class="product-card" data-aos="zoom-in" data-aos-delay="200">
@@ -255,7 +255,7 @@
                     <div class="p-6 text-center">
                         <h3 class="text-xl font-bold mb-3">The Expedition Pod</h3>
                         <p class="mb-4 text-gray-600">Secure and stylish portability with integrated Icebound Mode. Design cues taken from historic brass telescopes.</p>
-                        <a href="/products/pod.html" class="pre-order-button w-full">View Editions</a>
+                        <a href="products_pod.html" class="pre-order-button w-full">View Editions</a>
                     </div>
                 </div>
                 <div class="product-card" data-aos="zoom-in" data-aos-delay="300">
@@ -263,7 +263,7 @@
                     <div class="p-6 text-center">
                         <h3 class="text-xl font-bold mb-3">The Thermal Respite Mat</h3>
                         <p class="mb-4 text-gray-600">Adaptive thermal regulation via Icebound Mode, offering elemental protection. Inspired by the mariner's essential blanket.</p>
-                        <a href="/products/mat.html" class="pre-order-button w-full">View Editions</a>
+                        <a href="products_mat.html" class="pre-order-button w-full">View Editions</a>
                     </div>
                 </div>
                 <div class="product-card" data-aos="zoom-in" data-aos-delay="400">
@@ -271,7 +271,7 @@
                     <div class="p-6 text-center">
                         <h3 class="text-xl font-bold mb-3">The Culinary Companion Bowl</h3>
                         <p class="mb-4 text-gray-600">Dual-compartment design with Icebound Protection for sustenance anywhere. Echoes the utility of pewter mess tins.</p>
-                        <a href="/products/bowl.html" class="pre-order-button w-full">View Editions</a>
+                        <a href="products_bowl.html" class="pre-order-button w-full">View Editions</a>
                     </div>
                 </div>
             </div>

--- a/products_bowl.html
+++ b/products_bowl.html
@@ -114,18 +114,18 @@
     <!-- Navigation -->
     <nav class="nav">
         <div class="container mx-auto flex justify-between items-center h-12">
-            <a href="/index.html" class="text-xl font-bold text-white"><img src="/assets/images/pexpedition-logo.png" alt="Pexpedition Logo" class="h-8" loading="lazy"></a>
+            <a href="index.html" class="text-xl font-bold text-white"><img src="/assets/images/pexpedition-logo.png" alt="Pexpedition Logo" class="h-8" loading="lazy"></a>
             <div class="hamburger md:hidden cursor-pointer">
                 <i class="fas fa-bars"></i>
             </div>
             <ul class="nav-menu hidden md:flex space-x-6 items-center">
-                <li><a href="/index.html#home">Home</a></li>
-                <li><a href="/index.html#mission">Our Mission</a></li>
-                <li><a href="/index.html#products">Franklin Collection</a></li>
-                <li><a href="/index.html#franklin-expedition">Franklin Expedition</a></li>
-                <li><a href="/index.html#gallery">History</a></li>
-                <li><a href="/index.html#pre-order">Pre-Order</a></li>
-                <li><a href="/index.html#contact">Contact</a></li>
+                <li><a href="index.html#home">Home</a></li>
+                <li><a href="index.html#mission">Our Mission</a></li>
+                <li><a href="index.html#products">Franklin Collection</a></li>
+                <li><a href="index.html#franklin-expedition">Franklin Expedition</a></li>
+                <li><a href="index.html#gallery">History</a></li>
+                <li><a href="index.html#pre-order">Pre-Order</a></li>
+                <li><a href="index.html#contact">Contact</a></li>
                 <li><a href="#" class="snipcart-checkout"><i class="fas fa-shopping-cart"></i></a></li>
             </ul>
         </div>
@@ -181,7 +181,7 @@
                     data-item-custom1-required="false">Pre-Order</button>
             </div>
         </div>
-        <a href="/" class="block text-center mt-8 text-blue-600 hover:text-blue-800">Back to Collection</a>
+        <a href="index.html" class="block text-center mt-8 text-blue-600 hover:text-blue-800">Back to Collection</a>
     </div>
 
     <!-- Footer (consistent with index.html) -->

--- a/products_mat.html
+++ b/products_mat.html
@@ -114,18 +114,18 @@
     <!-- Navigation -->
     <nav class="nav">
         <div class="container mx-auto flex justify-between items-center h-12">
-            <a href="/index.html" class="text-xl font-bold text-white"><img src="/assets/images/pexpedition-logo.png" alt="Pexpedition Logo" class="h-8" loading="lazy"></a>
+            <a href="index.html" class="text-xl font-bold text-white"><img src="/assets/images/pexpedition-logo.png" alt="Pexpedition Logo" class="h-8" loading="lazy"></a>
             <div class="hamburger md:hidden cursor-pointer">
                 <i class="fas fa-bars"></i>
             </div>
             <ul class="nav-menu hidden md:flex space-x-6 items-center">
-                <li><a href="/index.html#home">Home</a></li>
-                <li><a href="/index.html#mission">Our Mission</a></li>
-                <li><a href="/index.html#products">Franklin Collection</a></li>
-                <li><a href="/index.html#franklin-expedition">Franklin Expedition</a></li>
-                <li><a href="/index.html#gallery">History</a></li>
-                <li><a href="/index.html#pre-order">Pre-Order</a></li>
-                <li><a href="/index.html#contact">Contact</a></li>
+                <li><a href="index.html#home">Home</a></li>
+                <li><a href="index.html#mission">Our Mission</a></li>
+                <li><a href="index.html#products">Franklin Collection</a></li>
+                <li><a href="index.html#franklin-expedition">Franklin Expedition</a></li>
+                <li><a href="index.html#gallery">History</a></li>
+                <li><a href="index.html#pre-order">Pre-Order</a></li>
+                <li><a href="index.html#contact">Contact</a></li>
                 <li><a href="#" class="snipcart-checkout"><i class="fas fa-shopping-cart"></i></a></li>
             </ul>
         </div>
@@ -181,7 +181,7 @@
                     data-item-custom1-required="false">Pre-Order</button>
             </div>
         </div>
-        <a href="/" class="block text-center mt-8 text-blue-600 hover:text-blue-800">Back to Collection</a>
+        <a href="index.html" class="block text-center mt-8 text-blue-600 hover:text-blue-800">Back to Collection</a>
     </div>
 
     <!-- Footer (consistent with index.html) -->

--- a/products_pod.html
+++ b/products_pod.html
@@ -114,18 +114,18 @@
     <!-- Navigation -->
     <nav class="nav">
         <div class="container mx-auto flex justify-between items-center h-12">
-            <a href="/index.html" class="text-xl font-bold text-white"><img src="/assets/images/pexpedition-logo.png" alt="Pexpedition Logo" class="h-8" loading="lazy"></a>
+            <a href="index.html" class="text-xl font-bold text-white"><img src="/assets/images/pexpedition-logo.png" alt="Pexpedition Logo" class="h-8" loading="lazy"></a>
             <div class="hamburger md:hidden cursor-pointer">
                 <i class="fas fa-bars"></i>
             </div>
             <ul class="nav-menu hidden md:flex space-x-6 items-center">
-                <li><a href="/index.html#home">Home</a></li>
-                <li><a href="/index.html#mission">Our Mission</a></li>
-                <li><a href="/index.html#products">Franklin Collection</a></li>
-                <li><a href="/index.html#franklin-expedition">Franklin Expedition</a></li>
-                <li><a href="/index.html#gallery">History</a></li>
-                <li><a href="/index.html#pre-order">Pre-Order</a></li>
-                <li><a href="/index.html#contact">Contact</a></li>
+                <li><a href="index.html#home">Home</a></li>
+                <li><a href="index.html#mission">Our Mission</a></li>
+                <li><a href="index.html#products">Franklin Collection</a></li>
+                <li><a href="index.html#franklin-expedition">Franklin Expedition</a></li>
+                <li><a href="index.html#gallery">History</a></li>
+                <li><a href="index.html#pre-order">Pre-Order</a></li>
+                <li><a href="index.html#contact">Contact</a></li>
                 <li><a href="#" class="snipcart-checkout"><i class="fas fa-shopping-cart"></i></a></li>
             </ul>
         </div>
@@ -181,7 +181,7 @@
                     data-item-custom1-required="false">Pre-Order</button>
             </div>
         </div>
-        <a href="/" class="block text-center mt-8 text-blue-600 hover:text-blue-800">Back to Collection</a>
+        <a href="index.html" class="block text-center mt-8 text-blue-600 hover:text-blue-800">Back to Collection</a>
     </div>
 
     <!-- Footer (consistent with index.html) -->

--- a/products_sanctuary.html
+++ b/products_sanctuary.html
@@ -114,18 +114,18 @@
     <!-- Navigation -->
     <nav class="nav">
         <div class="container mx-auto flex justify-between items-center h-12">
-            <a href="/index.html" class="text-xl font-bold text-white"><img src="/assets/images/pexpedition-logo.png" alt="Pexpedition Logo" class="h-8" loading="lazy"></a>
+            <a href="index.html" class="text-xl font-bold text-white"><img src="/assets/images/pexpedition-logo.png" alt="Pexpedition Logo" class="h-8" loading="lazy"></a>
             <div class="hamburger md:hidden cursor-pointer">
                 <i class="fas fa-bars"></i>
             </div>
             <ul class="nav-menu hidden md:flex space-x-6 items-center">
-                <li><a href="/index.html#home">Home</a></li>
-                <li><a href="/index.html#mission">Our Mission</a></li>
-                <li><a href="/index.html#products">Franklin Collection</a></li>
-                <li><a href="/index.html#franklin-expedition">Franklin Expedition</a></li>
-                <li><a href="/index.html#gallery">History</a></li>
-                <li><a href="/index.html#pre-order">Pre-Order</a></li>
-                <li><a href="/index.html#contact">Contact</a></li>
+                <li><a href="index.html#home">Home</a></li>
+                <li><a href="index.html#mission">Our Mission</a></li>
+                <li><a href="index.html#products">Franklin Collection</a></li>
+                <li><a href="index.html#franklin-expedition">Franklin Expedition</a></li>
+                <li><a href="index.html#gallery">History</a></li>
+                <li><a href="index.html#pre-order">Pre-Order</a></li>
+                <li><a href="index.html#contact">Contact</a></li>
                 <li><a href="#" class="snipcart-checkout"><i class="fas fa-shopping-cart"></i></a></li>
             </ul>
         </div>
@@ -181,7 +181,7 @@
                     data-item-custom1-required="false">Pre-Order</button>
             </div>
         </div>
-        <a href="/" class="block text-center mt-8 text-blue-600 hover:text-blue-800">Back to Collection</a>
+        <a href="index.html" class="block text-center mt-8 text-blue-600 hover:text-blue-800">Back to Collection</a>
     </div>
 
     <!-- Footer (consistent with index.html) -->


### PR DESCRIPTION
- Updated links from index.html to product pages to be relative (e.g., `products_sanctuary.html`).
- Updated navigation links within product pages back to index.html and its sections to be relative (e.g., `index.html#home`).
- Ensured 'Back to Collection' links on product pages point to `index.html`.

These changes ensure correct navigation when the site is hosted on GitHub Pages under a repository subpath.